### PR TITLE
Use HTTPS location for gpx.xsd

### DIFF
--- a/src/builder/BaseBuilder/BaseBuilder.ts
+++ b/src/builder/BaseBuilder/BaseBuilder.ts
@@ -13,7 +13,7 @@ export default class BaseBuilder {
     this.data = {};
     this.schemaLocation = [
       'http://www.topografix.com/GPX/1/1',
-      'http://www.topografix.com/GPX/1/1/gpx.xsd',
+      'https://www.topografix.com/GPX/1/1/gpx.xsd',
     ];
   }
 

--- a/tests/GarminBuilder.test.ts
+++ b/tests/GarminBuilder.test.ts
@@ -30,7 +30,7 @@ describe('Test Garmin builder', () => {
     ]);
     const gpxString = buildGPX(builder.toObject());
     expect(gpxString).toEqual(`<?xml version="1.0" encoding="UTF-8"?>
-<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www8.garmin.com/xmlschemas/GpxExtensions/v3/GpxExtensionsv3.xsd" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www8.garmin.com/xmlschemas/GpxExtensions/v3/GpxExtensionsv3.xsd" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
   <trk>
     <trkseg>
       <trkpt lat="0" lon="0">
@@ -75,7 +75,7 @@ describe('Test Garmin builder', () => {
     );
     const gpxString = buildGPX(builder.toObject());
     expect(gpxString).toEqual(`<?xml version="1.0" encoding="UTF-8"?>
-<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www8.garmin.com/xmlschemas/GpxExtensions/v3/GpxExtensionsv3.xsd" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 https://www8.garmin.com/xmlschemas/GpxExtensions/v3/GpxExtensionsv3.xsd" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
   <metadata>
     <name>testName</name>
     <desc>description</desc>

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -4,7 +4,7 @@ import { _experimentalParseGpx } from '../src/parser/parser';
 describe('parser', () => {
   it('parses routes', () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
   <rte>
     <rtept lat="51.02832496166229" lon="15.515156626701355">
       <ele>314.715</ele>
@@ -22,7 +22,7 @@ describe('parser', () => {
 
   it('parses waypoint', () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<gpx creator="fabulator:gpx-builder" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 https://www.topografix.com/GPX/1/1/gpx.xsd">
   <wpt lat="50.30434283427894" lon="12.176031740382314">
     <time>2022-12-23T17:22:36.000Z</time>
     <name>Start</name>


### PR DESCRIPTION
Dan Foster (TopoGrafix) switched the GPX website to use HTTPS some time ago.

Attempting to validate GPX files using the HTTP address of the XSD will fail in many instances, due to the re-direct.

e.g. https://www.freeformatter.com/xml-validator-xsd.html

The GPX namespace remains the same (i.e. HTTP) but the XSD should now be accessed via HTTPS.